### PR TITLE
Optimise `s-for` and `s-each`

### DIFF
--- a/evaluator.js
+++ b/evaluator.js
@@ -264,10 +264,9 @@ namespace("com.subnodal.subelements.evaluator", function(exports) {
                     rootNode.s_in = evalWithScope(rootNode.getAttribute("in") || "", scopeVariables);
                 }
 
-                rootNode.innerHTML = "";
-                renderChildren = false;
+                var fragment = document.createDocumentFragment();
 
-                var lastChildNodeLength = 0;
+                renderChildren = false;
 
                 for (var i = 0; i < Object.keys(rootNode.s_in || []).length; i++) {
                     if (rootNode.getAttribute("itervar")) {
@@ -282,14 +281,18 @@ namespace("com.subnodal.subelements.evaluator", function(exports) {
                         scopeVariables[rootNode.getAttribute("valuevar")] = rootNode.s_in[Object.keys(rootNode.s_in)[i]];
                     }
 
-                    rootNode.innerHTML += rootNode.s_innerHTML;
+                    rootNode.innerHTML = rootNode.s_innerHTML;
 
-                    for (var j = lastChildNodeLength; j < rootNode.childNodes.length; j++) {
-                        exports.evaluateTree(rootNode.childNodes[j], scopeVariables, false);
-                    }
+                    rootNode.childNodes.forEach(function(node) {
+                        exports.evaluateTree(node, scopeVariables, false);
 
-                    lastChildNodeLength = rootNode.childNodes.length;
+                        fragment.append(node.cloneNode(true));
+                    });
                 }
+
+                rootNode.innerHTML = "";
+
+                rootNode.append(fragment);
             } else if (rootNode.tagName == "S-SET") {
                 scopeVariables[rootNode.getAttribute("var")] = evalWithScope(rootNode.getAttribute("value") || "", scopeVariables);
             }

--- a/evaluator.js
+++ b/evaluator.js
@@ -234,24 +234,27 @@ namespace("com.subnodal.subelements.evaluator", function(exports) {
                     rootNode.s_step = evalWithScope(rootNode.getAttribute("step") || "", scopeVariables);
                 }
 
-                rootNode.innerHTML = "";
-                renderChildren = false;
+                var fragment = document.createDocumentFragment();
 
-                var lastChildNodeLength = 0;
+                renderChildren = false;
 
                 for (var i = Number(rootNode.s_start); i < Number(rootNode.s_stop); i += Number(rootNode.s_step) || 1) {
                     if (rootNode.getAttribute("var")) {
                         scopeVariables[rootNode.getAttribute("var")] = i;
                     }
 
-                    rootNode.innerHTML += rootNode.s_innerHTML;
+                    rootNode.innerHTML = rootNode.s_innerHTML;
 
-                    for (var j = lastChildNodeLength; j < rootNode.childNodes.length; j++) {
-                        exports.evaluateTree(rootNode.childNodes[j], scopeVariables, false);
-                    }
+                    rootNode.childNodes.forEach(function(node) {
+                        exports.evaluateTree(node, scopeVariables, false);
 
-                    lastChildNodeLength = rootNode.childNodes.length;
+                        fragment.append(node.cloneNode(true));
+                    });
                 }
+
+                rootNode.innerHTML = "";
+
+                rootNode.append(fragment);
             } else if (rootNode.tagName == "S-EACH") {
                 if (rootNode.s_innerHTML == undefined) {
                     rootNode.s_innerHTML = rootNode.innerHTML;


### PR DESCRIPTION
This PR optimises the `s-for` and `s-each` elements so that style and layout calculations are not performed for every iteration, but instead once iteration is complete.

Rendering 100 elements went from about 60 ms to 30 ms, which is a nice improvement of about 50%.